### PR TITLE
get structured requirements for a package

### DIFF
--- a/lib/CPAN/Meta/Requirements.pm
+++ b/lib/CPAN/Meta/Requirements.pm
@@ -666,11 +666,11 @@ sub from_string_hash {
 
     my @parts;
 
-    for my $pair (
+    for my $tuple (
       [ qw( >= > minimum ) ],
       [ qw( <= < maximum ) ],
     ) {
-      my ($op, $e_op, $k) = @$pair;
+      my ($op, $e_op, $k) = @$tuple;
       if (exists $self->{$k}) {
         my @new_exclusions = grep { $_ != $self->{ $k } } @exclusions;
         if (@new_exclusions == @exclusions) {

--- a/lib/CPAN/Meta/Requirements.pm
+++ b/lib/CPAN/Meta/Requirements.pm
@@ -218,7 +218,7 @@ BEGIN {
 
       return $self;
     };
-    
+
     no strict 'refs';
     *$to_add = $code;
   }
@@ -346,7 +346,7 @@ sub requirements_for_module {
   $req->structured_requirements_for_module( $module );
 
 This returns a data structure containing the version requirements for a given
-module or undef if the given module has no requirements.  This should 
+module or undef if the given module has no requirements.  This should
 not be used for version checks (see L</accepts_module> instead).
 
 =cut
@@ -678,8 +678,6 @@ sub from_string_hash {
     my ($self) = @_;
 
     return 0 if ! keys %$self;
-
-    # return "$self->{minimum}" if (keys %$self) == 1 and exists $self->{minimum};
 
     my @exclusions = @{ $self->{exclusions} || [] };
 

--- a/lib/CPAN/Meta/Requirements.pm
+++ b/lib/CPAN/Meta/Requirements.pm
@@ -330,7 +330,7 @@ This returns a string containing the version requirements for a given module in
 the format described in L<CPAN::Meta::Spec> or undef if the given module has no
 requirements. This should only be used for informational purposes such as error
 messages and should not be interpreted or used for comparison (see
-L</accepts_module> instead.)
+L</accepts_module> instead).
 
 =cut
 
@@ -346,9 +346,8 @@ sub requirements_for_module {
   $req->structured_requirements_for_module( $module );
 
 This returns a data structure containing the version requirements for a given
-module or undef if the given module has no requirements.  This should only be
-used for informational purposes such as error messages and should not be
-interpreted or used for comparison (see L</accepts_module> instead.)
+module or undef if the given module has no requirements.  This should 
+not be used for version checks (see L</accepts_module> instead).
 
 =cut
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -194,8 +194,8 @@ sub dies_ok (&@) {
     # remember, it's okay to change the exact results, as long as the meaning
     # is unchanged -- rjbs, 2012-07-11
     [
-      [ '<=', '3' ],
       [ '>=', '1' ],
+      [ '<=', '3' ],
       [ '!=', '2' ],
     ],
     "structured requirements for Foo",

--- a/t/basic.t
+++ b/t/basic.t
@@ -188,6 +188,18 @@ sub dies_ok (&@) {
     },
     'test exclusion-skipping',
   );
+
+  is_deeply(
+    $req->structured_requirements_for_module('Foo'),
+    # remember, it's okay to change the exact results, as long as the meaning
+    # is unchanged -- rjbs, 2012-07-11
+    [
+      [ '<=', '3' ],
+      [ '>=', '1' ],
+      [ '!=', '2' ],
+    ],
+    "structured requirements for Foo",
+  );
 }
 
 sub foo_1 {
@@ -225,6 +237,12 @@ sub foo_1 {
   my $req = foo_1;
 
   is($req->requirements_for_module('Foo'), '== 1', 'requirements_for_module');
+
+  is_deeply(
+    $req->structured_requirements_for_module('Foo'),
+    [ [ '==', '1' ] ],
+    'structured_requirements_for_module'
+  );
 
   # test empty/undef returns
   my @list = $req->requirements_for_module('FooBarBamBaz');


### PR DESCRIPTION
Right now, you can ask for the requirements for a module and get "> 3, < 4" but you can't get the structured data.

This branch (which I wrote three years ago and forgot about!) adds a mechanism to get an arrayref of arrayrefs.  The inner arrayrefs are pairs of comparator and version.